### PR TITLE
Feature/natyosu3/#2 単語を提供するAPIの実装

### DIFF
--- a/cmd/FlickGameBack/main.go
+++ b/cmd/FlickGameBack/main.go
@@ -3,13 +3,20 @@ package main
 import (
 	"FlickGameBack/pkg/db/create"
 	"FlickGameBack/pkg/engine"
+	"FlickGameBack/pkg/util"
 
 	"github.com/gin-gonic/gin"
 )
 
-func main() {
+func init() {
 	// デフォルトのテーブルを作成
 	create.CreateDefaultTable()
+
+	// デフォルトの単語を追加
+	util.AddWord()
+}
+
+func main() {
 	r := gin.Default()
 	r = engine.Engine(r)
 	r.Run(":8080")

--- a/cmd/FlickGameBack/main.go
+++ b/cmd/FlickGameBack/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"FlickGameBack/pkg/db/create"
+	"FlickGameBack/pkg/engine"
 
 	"github.com/gin-gonic/gin"
 )
@@ -10,10 +11,6 @@ func main() {
 	// デフォルトのテーブルを作成
 	create.CreateDefaultTable()
 	r := gin.Default()
-	r.GET("/", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"message": "FlickGameBack",
-		})
-	})
+	r = engine.Engine(r)
 	r.Run(":8080")
 }

--- a/pkg/db/connect.go
+++ b/pkg/db/connect.go
@@ -19,10 +19,12 @@ func Connect() *sql.DB {
 	db, err := sql.Open("postgres", DB_DSN)
 	if err != nil {
 		slog.Error("failed to connect database", "err=", err)
+		panic(err)
 	}
 
 	if err = db.Ping(); err != nil {
 		slog.Error("failed to ping database", "err=", err)
+		panic(err)
 	}
 
 	return db

--- a/pkg/db/create/default.go
+++ b/pkg/db/create/default.go
@@ -13,7 +13,7 @@ func CreateDefaultTable() {
 	defer db.Close()
 
 	var sql_stm []string = []string{
-		`create table IF NOT EXISTS "word" (word_id text PRIMARY KEY, word_text text NOT NULL, word_level text, point_allocation int)`,
+		`create table IF NOT EXISTS "word" (word_id text PRIMARY KEY, word_text text, word_furigana text, word_level text, point_allocation int)`,
 	}
 
 	for _, stm := range sql_stm {

--- a/pkg/db/create/insert_word.go
+++ b/pkg/db/create/insert_word.go
@@ -1,0 +1,21 @@
+package create
+
+import (
+	"FlickGameBack/pkg/db"
+	"FlickGameBack/pkg/model"
+	"log/slog"
+)
+
+// 単語を追加する
+func InsertWord(word model.Word) error {
+	db := db.Connect()
+	defer db.Close()
+
+	_, err := db.Exec("INSERT INTO word (word_id, word_text, word_furigana, word_level, point_allocation) VALUES ($1, $2, $3, $4, $5)", word.WordId, word.WordText, word.WordFurigana, word.WordLevel, word.PointAllocation)
+	if err != nil {
+		slog.Error("failed to insert word", "err=", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/db/read/read.go
+++ b/pkg/db/read/read.go
@@ -7,24 +7,26 @@ import (
 )
 
 // 単語を取得する
-func ReadWords(level string, count int) []model.Word {
+func ReadWords(level string, count int) ([]model.Word, error) {
 	db := db.Connect()
 	defer db.Close()
 
 	var words []model.Word
-	rows, err := db.Query("SELECT * FROM word WHERE word_level = $1 ORDER BY RANDOM() LIMIT $2", level, count)
+	rows, err := db.Query("SELECT word_id, word_text, word_furigana, word_level, point_allocation FROM word WHERE word_level = $1 ORDER BY RANDOM() LIMIT $2", level, count)
 	if err != nil {
 		slog.Error("failed to select words", "err=", err)
+		return nil, err
 	}
 
 	for rows.Next() {
 		var word model.Word
-		err := rows.Scan(&word.WordId, &word.WordText, &word.WordLevel, &word.PointAllocation)
+		err := rows.Scan(&word.WordId, &word.WordText, &word.WordFurigana, &word.WordLevel, &word.PointAllocation)
 		if err != nil {
 			slog.Error("failed to scan word", "err=", err)
+			return nil, err
 		}
 		words = append(words, word)
 	}
 
-	return words
+	return words, nil
 }

--- a/pkg/db/read/read.go
+++ b/pkg/db/read/read.go
@@ -1,0 +1,30 @@
+package read
+
+import (
+	"FlickGameBack/pkg/db"
+	"FlickGameBack/pkg/model"
+	"log/slog"
+)
+
+// 単語を取得する
+func ReadWords(level string, count int) []model.Word {
+	db := db.Connect()
+	defer db.Close()
+
+	var words []model.Word
+	rows, err := db.Query("SELECT * FROM word WHERE word_level = $1 ORDER BY RANDOM() LIMIT $2", level, count)
+	if err != nil {
+		slog.Error("failed to select words", "err=", err)
+	}
+
+	for rows.Next() {
+		var word model.Word
+		err := rows.Scan(&word.WordId, &word.WordText, &word.WordLevel, &word.PointAllocation)
+		if err != nil {
+			slog.Error("failed to scan word", "err=", err)
+		}
+		words = append(words, word)
+	}
+
+	return words
+}

--- a/pkg/engine/core/word-get.go
+++ b/pkg/engine/core/word-get.go
@@ -1,0 +1,15 @@
+package core
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// 単語を取得するエンドポイントハンドラ
+func WordGet() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		word := "apple"
+		c.JSON(200, gin.H{
+			"word": word,
+		})
+	}
+}

--- a/pkg/engine/core/word-get.go
+++ b/pkg/engine/core/word-get.go
@@ -1,15 +1,40 @@
 package core
 
 import (
+	"FlickGameBack/pkg/db/read"
+	"strconv"
+
 	"github.com/gin-gonic/gin"
 )
 
 // 単語を取得するエンドポイントハンドラ
 func WordGet() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		word := "apple"
-		c.JSON(200, gin.H{
-			"word": word,
-		})
+		// クエリパラメータを取得
+		level := c.Query("level")
+		count_str := c.Query("count")
+
+		// クエリパラメータがない場合はエラー
+		if level == "" || count_str == "" {
+			c.JSON(400, gin.H{"error": "level and count are required"})
+			return
+		}
+
+		// countパラメータをintに変換
+		count, err := strconv.Atoi(count_str)
+		if err != nil {
+			c.JSON(400, gin.H{"error": "count must be an integer"})
+			return
+		}
+
+		// DBから単語を取得
+		words, err := read.ReadWords(level, count)
+		if err != nil {
+			c.JSON(500, gin.H{"error": "failed to read words"})
+			return
+		}
+
+		// レスポンス
+		c.JSON(200, gin.H{"data": words})
 	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,0 +1,17 @@
+package engine
+
+import (
+	"FlickGameBack/pkg/engine/core"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Engine(r *gin.Engine) *gin.Engine {
+	// ログとリカバリーのミドルウェアを設定(デフォルト)
+	r.Use(gin.Logger())
+	r.Use(gin.Recovery())
+
+	// ルーティング
+	r.GET("/word-get", core.WordGet())
+	return r
+}

--- a/pkg/model/word_model.go
+++ b/pkg/model/word_model.go
@@ -3,6 +3,7 @@ package model
 type Word struct {
 	WordId          string `json:"word_id"`
 	WordText        string `json:"word_text"`
+	WordFurigana    string `json:"word_furigana"`
 	WordLevel       string `json:"word_level"`
 	PointAllocation int    `json:"point_allocation"`
 }

--- a/pkg/model/word_model.go
+++ b/pkg/model/word_model.go
@@ -1,0 +1,8 @@
+package model
+
+type Word struct {
+	WordId          string `json:"word_id"`
+	WordText        string `json:"word_text"`
+	WordLevel       string `json:"word_level"`
+	PointAllocation int    `json:"point_allocation"`
+}

--- a/pkg/util/add_word.go
+++ b/pkg/util/add_word.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"FlickGameBack/pkg/db/create"
+	"FlickGameBack/pkg/model"
+)
+
+// 単語を追加する
+func AddWord() error {
+	words := []model.Word{
+		{WordId: "1", WordText: "猫", WordFurigana: "ネコ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "2", WordText: "犬", WordFurigana: "イヌ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "3", WordText: "鳥", WordFurigana: "トリ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "4", WordText: "魚", WordFurigana: "サカナ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "5", WordText: "熊", WordFurigana: "クマ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "6", WordText: "猿", WordFurigana: "サル", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "7", WordText: "狼", WordFurigana: "オオカミ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "8", WordText: "虎", WordFurigana: "トラ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "9", WordText: "獅子", WordFurigana: "シシ", WordLevel: "normal", PointAllocation: 1},
+		{WordId: "10", WordText: "鹿", WordFurigana: "シカ", WordLevel: "normal", PointAllocation: 1},
+	}
+
+	for _, word := range words {
+		if err := create.InsertWord(word); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
単語を提供するAPIを実装しました。

仮で単語情報の全てをレスポンスとして返していますが、front側で必要な情報だけ欲しいとなれば、簡単にレスポンスのデータ構造を変更できるので、問題ないと思われます。
ex: 
現在は
```go
	WordId          string `json:"word_id"`
	WordText        string `json:"word_text"`
	WordFurigana    string `json:"word_furigana"`
	WordLevel       string `json:"word_level"`
	PointAllocation int    `json:"point_allocation"`
```
と全て返していますが、front側ではIDが必要ない、別のデータも欲しいとなれば付け加えたり削除することが簡単にできるということです。


ER図も現在まとめ中でまとまり次第共有します。

単語のデータを登録する専用のAPIも(必要だと感じたので)実装します。
↑(DB登録周りでIDの付与等処理が必要なため)

## 出力例
![image](https://github.com/user-attachments/assets/ea4a1d29-3a64-487d-9922-e56b0499b1c2)
