### PR TITLE
patch: /word-getエンドポイントのレスポンスJSONを更新

### DIFF
--- a/pkg/db/create/default.go
+++ b/pkg/db/create/default.go
@@ -14,23 +14,9 @@ func CreateDefaultTable() {
 
 	var sql_stm []string = []string{
 		`create table IF NOT EXISTS "user" (user_id text PRIMARY KEY, username text UNIQUE NOT NULL, nickname text NOT NULL, password_hash text)`,
-		`create table IF NOT EXISTS "level" (level_name text PRIMARY KEY)`,
-		`create table IF NOT EXISTS "score" (score_id serial PRIMARY KEY, user_id text, point int, average_speed float, level text,FOREIGN KEY (user_id) REFERENCES "user"(user_id), FOREIGN KEY (level) REFERENCES "level"(level_name))`,
+		`create table IF NOT EXISTS "level" (level_name text PRIMARY KEY, limit_time int)`,
+		`create table IF NOT EXISTS "score" (score_id serial PRIMARY KEY, user_id text, point int, level text,FOREIGN KEY (user_id) REFERENCES "user"(user_id), FOREIGN KEY (level) REFERENCES "level"(level_name))`,
 		`create table IF NOT EXISTS "word" (word_id text PRIMARY KEY, word_text text UNIQUE NOT NULL, word_furigana text NOT NULL, word_level text, point_allocation int NOT NULL, FOREIGN KEY (word_level) REFERENCES level(level_name))`,
-	}
-
-	// 存在しなければ, レベルのデフォルト値を挿入easy, normal, hard
-	_, err := db.Exec(`insert into level (level_name) select 'easy' where not exists (select * from level where level_name = 'easy')`)
-	if err != nil {
-		slog.Error("failed to insert level", "err=", err)
-	}
-	_, err = db.Exec(`insert into level (level_name) select 'normal' where not exists (select * from level where level_name = 'normal')`)
-	if err != nil {
-		slog.Error("failed to insert level", "err=", err)
-	}
-	_, err = db.Exec(`insert into level (level_name) select 'hard' where not exists (select * from level where level_name = 'hard')`)
-	if err != nil {
-		slog.Error("failed to insert level", "err=", err)
 	}
 
 	for _, stm := range sql_stm {
@@ -39,5 +25,34 @@ func CreateDefaultTable() {
 			slog.Error("failed to create table", "err=", err)
 		}
 	}
+	// レベルテーブルのイニシャライズ
+	InitLevelTable()
 	slog.Info("create default table")
+}
+
+// レベルテーブルのイニシャライズ
+func InitLevelTable() {
+	db := db.Connect()
+	defer db.Close()
+
+	// レベルテーブルを削除し作成しなおす
+	_, err := db.Exec(`delete from "level"`)
+	if err != nil {
+		slog.Error("failed to delete level", "err=", err)
+	}
+
+	// レベル名, 制限時間
+	var sql_stm []string = []string{
+		`insert into "level" (level_name, limit_time) values ('easy', 60)`,
+		`insert into "level" (level_name, limit_time) values ('normal', 90)`,
+		`insert into "level" (level_name, limit_time) values ('hard', 120)`,
+	}
+
+	for _, stm := range sql_stm {
+		_, err := db.Exec(stm)
+		if err != nil {
+			slog.Error("failed to insert level", "err=", err)
+		}
+	}
+	slog.Info("init level table")
 }

--- a/pkg/db/read/get_limit_time.go
+++ b/pkg/db/read/get_limit_time.go
@@ -1,0 +1,20 @@
+package read
+
+import (
+	"FlickGameBack/pkg/db"
+	"log/slog"
+)
+
+// 指定されたレベルの制限時間を取得する関数
+func ReadLimitTime(level string) (int, error) {
+	db := db.Connect()
+	defer db.Close()
+
+	var limitTime int
+	err := db.QueryRow(`select limit_time from level where level_name = $1`, level).Scan(&limitTime)
+	if err != nil {
+		slog.Error("failed to read limit time", "err=", err)
+		return 0, err
+	}
+	return limitTime, nil
+}

--- a/pkg/engine/core/word-get.go
+++ b/pkg/engine/core/word-get.go
@@ -34,7 +34,17 @@ func WordGet() gin.HandlerFunc {
 			return
 		}
 
+		// DBから制限時間を取得
+		limit_time, err := read.ReadLimitTime(level)
+		if err != nil {
+			c.JSON(500, gin.H{"error": "failed to read limit time"})
+			return
+		}
+
 		// レスポンス
-		c.JSON(200, gin.H{"data": words})
+		c.JSON(200, gin.H{
+			"limit_time": limit_time,
+			"words":      words,
+		})
 	}
 }

--- a/pkg/model/level_mode.go
+++ b/pkg/model/level_mode.go
@@ -1,0 +1,6 @@
+package model
+
+type Level struct {
+	LevelName string `json:"level_name"`
+	LimitTime int    `json:"limit_time"`
+}


### PR DESCRIPTION
```json
{
    "limit_time": 60,
    "words": [
        {
            "word_id": "POrGI9IGFH1Z",
            "word_text": "狼",
            "word_furigana": "おおかみ",
            "word_level": "easy",
            "point_allocation": 3
        },
        {
            "word_id": "tZ0GmfsJguKJ",
            "word_text": "鳥",
            "word_furigana": "とり",
            "word_level": "easy",
            "point_allocation": 2
        }
    ]
}
```

* limit_time: 制限時間をデータに追加
* 問題配列のキーをdataからwordsに変更

## 実行結果
![image](https://github.com/user-attachments/assets/bdfd32b3-f014-4fcf-9d6e-401ab3408ade)

